### PR TITLE
Implement multi-crewing

### DIFF
--- a/src/main/java/net/tylers1066/beaming/Beaming.java
+++ b/src/main/java/net/tylers1066/beaming/Beaming.java
@@ -1,16 +1,20 @@
 package net.tylers1066.beaming;
 
 import com.earth2me.essentials.Essentials;
+import net.countercraft.movecraft.craft.Craft;
+import net.tylers1066.beaming.commands.AbandonShipCommand;
 import net.tylers1066.beaming.commands.BeamCommand;
 import net.tylers1066.beaming.commands.CrewbedCommand;
 import net.tylers1066.beaming.config.Config;
 import net.tylers1066.beaming.listener.DeathListener;
+import net.tylers1066.beaming.listener.ReleaseListener;
 import net.tylers1066.beaming.listener.RespawnListener;
 import net.tylers1066.beaming.localisation.I18nSupport;
 import net.tylers1066.beaming.sign.CrewSign;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -19,6 +23,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -26,6 +31,8 @@ public class Beaming extends JavaPlugin implements Listener {
     public static final String PREFIX = ChatColor.DARK_BLUE + "[" + ChatColor.YELLOW + "Beaming" + ChatColor.DARK_BLUE + "] " + ChatColor.RED;
     private static Beaming instance;
     private static Essentials essentials = null;
+
+    private HashMap<Player, Craft> crewCrafts = new HashMap<>();
 
     public static Beaming getInstance() {
         return instance;
@@ -113,6 +120,7 @@ public class Beaming extends JavaPlugin implements Listener {
 
         if (Config.EnableCrewSigns) {
             getServer().getPluginManager().registerEvents(new CrewSign(), this);
+            getServer().getPluginManager().registerEvents(new ReleaseListener(), this);
         }
 
         if (Config.SetHomeToCrewSign) {
@@ -130,6 +138,7 @@ public class Beaming extends JavaPlugin implements Listener {
 
         getCommand("beam").setExecutor(new BeamCommand());
         getCommand("crewbed").setExecutor(new CrewbedCommand());
+        getCommand("abandonship").setExecutor(new AbandonShipCommand());
         getServer().getPluginManager().registerEvents(new DeathListener(), this);
     }
 
@@ -137,4 +146,6 @@ public class Beaming extends JavaPlugin implements Listener {
     public Essentials getEssentials() {
         return essentials;
     }
+
+    public HashMap<Player, Craft> getCrewCrafts() {return crewCrafts;}
 }

--- a/src/main/java/net/tylers1066/beaming/commands/AbandonShipCommand.java
+++ b/src/main/java/net/tylers1066/beaming/commands/AbandonShipCommand.java
@@ -1,0 +1,40 @@
+package net.tylers1066.beaming.commands;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.craft.PlayerCraft;
+import net.countercraft.movecraft.craft.type.CraftType;
+import net.tylers1066.beaming.Beaming;
+import net.tylers1066.beaming.localisation.I18nSupport;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class AbandonShipCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String s, @NotNull String[] args) {
+        if (!cmd.getName().equalsIgnoreCase("abandonship")) {
+            return false;
+        }
+
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(Beaming.PREFIX + I18nSupport.getInternationalisedString("Players Only"));
+            return true;
+        }
+
+        if (Beaming.getInstance().getCrewCrafts().containsKey((Player)sender)) {
+            Craft craft = Beaming.getInstance().getCrewCrafts().get(sender);
+
+            if (craft instanceof PlayerCraft) {
+                sender.sendMessage(Beaming.PREFIX + String.format(I18nSupport.getInternationalisedString("Abandoned Ship"), craft.getType().getStringProperty(CraftType.NAME), ((PlayerCraft) craft).getPilot().getDisplayName()));
+            }
+            Beaming.getInstance().getCrewCrafts().remove((Player)sender);
+        } else {
+            sender.sendMessage(Beaming.PREFIX + I18nSupport.getInternationalisedString("No Crew Craft Found"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/net/tylers1066/beaming/listener/ReleaseListener.java
+++ b/src/main/java/net/tylers1066/beaming/listener/ReleaseListener.java
@@ -1,0 +1,31 @@
+package net.tylers1066.beaming.listener;
+
+import net.countercraft.movecraft.craft.Craft;
+import net.countercraft.movecraft.events.CraftReleaseEvent;
+import net.tylers1066.beaming.Beaming;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ReleaseListener implements Listener {
+    @EventHandler
+    public void onCraftRelease (CraftReleaseEvent event) {
+        Map<Player, Craft> crewMap = Beaming.getInstance().getCrewCrafts();
+        if (crewMap.containsValue(event.getCraft())) {
+            List<Player> removalList = new ArrayList<>();
+            for (Player player : crewMap.keySet()) {
+                Craft craft = crewMap.get(player);
+                if (craft == event.getCraft()) {
+                    removalList.add(player);
+                }
+            }
+            for (Player player : removalList) {
+                crewMap.remove(player);
+            }
+        }
+    }
+}

--- a/src/main/java/net/tylers1066/beaming/sign/CrewSign.java
+++ b/src/main/java/net/tylers1066/beaming/sign/CrewSign.java
@@ -61,10 +61,7 @@ public class CrewSign implements Listener {
             player.sendMessage(I18nSupport.getInternationalisedString("CrewSign - Need Bed Below"));
             return;
         }
-        if (!sign.getLine(1).equalsIgnoreCase(player.getName())) {
-            player.sendMessage(I18nSupport.getInternationalisedString("CrewSign - Sign Not Owned"));
-            return;
-        }
+
         if (CraftManager.getInstance().getCraftByPlayer(player) != null) {
             player.sendMessage(I18nSupport.getInternationalisedString("CrewSign - Craft Currently Piloted"));
             return;
@@ -84,6 +81,12 @@ public class CrewSign implements Listener {
                 return;
             }
         }
+
+        if (!sign.getLine(1).equalsIgnoreCase(player.getName())) {
+            player.sendMessage(I18nSupport.getInternationalisedString("CrewSign - Sign Not Owned"));
+            return;
+        }
+        
         player.sendMessage(I18nSupport.getInternationalisedString("CrewSign - Spawn Set"));
         player.setBedSpawnLocation(location, true);
         sign.setLine(0, ChatColor.BOLD + "Crew:");

--- a/src/main/resources/localisation/beaminglang_en.properties
+++ b/src/main/resources/localisation/beaminglang_en.properties
@@ -14,3 +14,5 @@ CrewSign\ -\ Respawn=Respawning at crew bed\!
 CrewBed\ -\ Current\ Location=Your crew bed is at
 CrewBed\ -\ Priority\ Location=Your priority crew bed is at
 CrewBed\ -\ No\ Location=You do not have a crew bed set.
+Joined\ Ship=Joined the crew of the %s commanded by %s
+Abandoned\ Ship=Abandoned the %s commanded by %s

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,3 +18,8 @@ commands:
     usage: /crewbed
     permission: beaming.crewbed
     permission-message: You don't have the beaming.crewbed permission.
+  abandonship:
+    description: Removes you from the crew of all crafts.
+    usage: /abandonship
+    permission: beaming.abandonship
+    permission-message: You don't have the beaming.abandonship permission.


### PR DESCRIPTION
This PR allows players to add themselves to the crew of a craft, and then respawn at their crew sign while it is piloted. To do this, they must simply have a crew sign on the craft and shift-right click it when the craft is piloted. From then on, they will respawn at that craft until it is either destroyed or they use the new /abandonship command.